### PR TITLE
Update recent on rename

### DIFF
--- a/src/FolderManager/File.vala
+++ b/src/FolderManager/File.vala
@@ -179,7 +179,10 @@ namespace Scratch.FolderManager {
         public void rename (string name) {
             try {
                 if (exists) {
-                    file.set_display_name (name);
+                    var recent_manager = Gtk.RecentManager.get_default ();
+                    var new_file = file.set_display_name (name);
+                    recent_manager.add_item (new_file.get_uri ());
+                    file = new_file;
                 }
             } catch (GLib.Error error) {
                 warning (error.message);

--- a/src/FolderManager/File.vala
+++ b/src/FolderManager/File.vala
@@ -182,7 +182,8 @@ namespace Scratch.FolderManager {
                     var recent_manager = Gtk.RecentManager.get_default ();
                     var new_file = file.set_display_name (name);
                     recent_manager.add_item (new_file.get_uri ());
-                    file = new_file;
+                    // Do not change existing file as this item will
+                    // be removed by its parent folder under that name
                 }
             } catch (GLib.Error error) {
                 warning (error.message);


### PR DESCRIPTION
This works to update "Recent Files" when a sidebar item is renamed.  The old name is automatically removed.

